### PR TITLE
Inject MLproject env vars to the Docker image when running on Kubernetes

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -148,6 +148,7 @@ def _run(
             base_image=project.docker_env.get("image"),
             run_id=active_run.info.run_id,
             tag=kube_config.get("image-tag"),
+            user_env_vars=project.docker_env.get("environment"),
         )
         image_digest = kb.push_image_to_registry(image.tags[0])
         submitted_run = kb.run_kubernetes_job(


### PR DESCRIPTION
Because now they are taken into account only if running the docker container locally.